### PR TITLE
Add WHIP WebRTC streaming support

### DIFF
--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -24671,6 +24671,9 @@
         }
       }
     },
+    "Add STUN server" : {
+
+    },
     "Advanced" : {
       "localizations" : {
         "de" : {
@@ -26304,6 +26307,9 @@
           }
         }
       }
+    },
+    "Also supported: whips:// and whip://" : {
+
     },
     "Alternatively, use a website as assistant." : {
       "localizations" : {
@@ -36933,6 +36939,9 @@
           }
         }
       }
+    },
+    "Bearer token (optional)" : {
+
     },
     "Beauty" : {
       "localizations" : {
@@ -48177,6 +48186,7 @@
       }
     },
     "Chat is empty." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -57951,6 +57961,7 @@
       }
     },
     "Create stream marker" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -76289,6 +76300,9 @@
           }
         }
       }
+    },
+    "Example: https://whip.example.com/ingest/stream" : {
+
     },
     "Example: rtmp://a.rtmp.youtube.com/live2/1bk2-0d03-9683-7k65-e4d3" : {
       "localizations" : {
@@ -109997,6 +110011,9 @@
         }
       }
     },
+    "Malformed WHIP URL" : {
+
+    },
     "Manage streams" : {
       "localizations" : {
         "de" : {
@@ -133952,6 +133969,12 @@
         }
       }
     },
+    "Optional STUN server list. Example: stun:stun.example.com:3478" : {
+
+    },
+    "Optional token sent as Authorization: Bearer <token> when connecting to the WHIP server." : {
+
+    },
     "Optional, but simplifies the setup." : {
       "localizations" : {
         "de" : {
@@ -134249,6 +134272,7 @@
       }
     },
     "Other" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -159856,6 +159880,7 @@
       }
     },
     "Save replay" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -167280,6 +167305,7 @@
       }
     },
     "Set clock" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -190177,6 +190203,9 @@
         }
       }
     },
+    "stun:stun.example.com:3478" : {
+
+    },
     "Style sheet" : {
       "localizations" : {
         "de" : {
@@ -196244,6 +196273,9 @@
           }
         }
       }
+    },
+    "Template: https://my_whip_server/whip/endpoint" : {
+
     },
     "Template: rtmp://[nearby_ingest_endpoint](https://help.twitch.tv/s/twitch-ingest-recommendation)/app/" : {
       "localizations" : {
@@ -223902,6 +223934,36 @@
 
     },
     "When \"Audio only\" mode is selected, no video will be rendered at all. Only audio will play." : {
+
+    },
+    "WHIP" : {
+
+    },
+    "WHIP answer missing" : {
+
+    },
+    "WHIP answer rejected" : {
+
+    },
+    "WHIP bad server response" : {
+
+    },
+    "WHIP connect failed" : {
+
+    },
+    "WHIP disconnected (%@)" : {
+
+    },
+    "WHIP offer failed" : {
+
+    },
+    "WHIP sends one H.264 video track and one Opus audio track." : {
+
+    },
+    "WHIP server returned %lld" : {
+
+    },
+    "whips:// maps to https://, whip:// maps to http://" : {
 
     },
     "Whirlpool" : {

--- a/Common/Various/Validate.swift
+++ b/Common/Various/Validate.swift
@@ -56,6 +56,13 @@ func isValidRistUrl(url: String) -> String? {
     return nil
 }
 
+func isValidWhipUrl(url: String) -> String? {
+    guard URL(string: url) != nil else {
+        return String(localized: "Malformed WHIP URL")
+    }
+    return nil
+}
+
 private func isValidIrlUrl(url: String) -> String? {
     guard URL(string: url) != nil else {
         return String(localized: "Malformed IRL URL")
@@ -105,6 +112,22 @@ func isValidUrl(url value: String,
         }
     case "rist":
         if let message = isValidRistUrl(url: value) {
+            return message
+        }
+    case "whip":
+        if let message = isValidWhipUrl(url: value) {
+            return message
+        }
+    case "whips":
+        if let message = isValidWhipUrl(url: value) {
+            return message
+        }
+    case "http":
+        if let message = isValidWhipUrl(url: value) {
+            return message
+        }
+    case "https":
+        if let message = isValidWhipUrl(url: value) {
             return message
         }
     case "irl":

--- a/Moblin.xcodeproj/project.pbxproj
+++ b/Moblin.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		035351942F1C271700428DAC /* AppAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 035351932F1C271700428DAC /* AppAuthCore */; };
 		035351962F1C27A500428DAC /* AppAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 035351952F1C27A500428DAC /* AppAuth */; };
 		0360FD162F228EEB00FF8847 /* MetalPetal in Frameworks */ = {isa = PBXBuildFile; productRef = 0360FD152F228EEB00FF8847 /* MetalPetal */; };
+		03D5A1C22F5A600100A1B2C3 /* libdatachannel in Frameworks */ = {isa = PBXBuildFile; productRef = 03D5A1C12F5A600100A1B2C3 /* libdatachannel */; };
 		0376F6F92B9511030056B3D2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0376F6F82B9511030056B3D2 /* WidgetKit.framework */; };
 		0376F6FB2B9511030056B3D2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0376F6FA2B9511030056B3D2 /* SwiftUI.framework */; };
 		0376F7042B9511040056B3D2 /* MoblinWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0376F6F72B9511030056B3D2 /* MoblinWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -230,6 +231,7 @@
 				03A08B7C2AC295620018BA95 /* AlertToast in Frameworks */,
 				0377239C2DE35191007D040D /* VRMSceneKit in Frameworks */,
 				03BC116B2AE56C2200C38FC4 /* SDWebImageWebPCoder in Frameworks */,
+				03D5A1C22F5A600100A1B2C3 /* libdatachannel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,6 +366,7 @@
 				035351932F1C271700428DAC /* AppAuthCore */,
 				035351952F1C27A500428DAC /* AppAuth */,
 				0360FD152F228EEB00FF8847 /* MetalPetal */,
+				03D5A1C12F5A600100A1B2C3 /* libdatachannel */,
 			);
 			productName = Mobs;
 			productReference = 035E9E332A9A02D6009D4F5A /* Moblin.app */;
@@ -519,6 +522,7 @@
 				882D0C142DF76F5B0035BFAF /* XCRemoteSwiftPackageReference "BlackSharkLib" */,
 				035351922F1C271700428DAC /* XCRemoteSwiftPackageReference "AppAuth-iOS" */,
 				0360FD142F228EEB00FF8847 /* XCRemoteSwiftPackageReference "MetalPetal" */,
+				03D5A1C02F5A600100A1B2C3 /* XCLocalSwiftPackageReference "Packages/LibDataChannelPackage" */,
 			);
 			productRefGroup = 035E9E342A9A02D6009D4F5A /* Products */;
 			projectDirPath = "";
@@ -1214,6 +1218,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		03D5A1C02F5A600100A1B2C3 /* XCLocalSwiftPackageReference "Packages/LibDataChannelPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/LibDataChannelPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		0318D3682CF51D6900E12F3B /* XCRemoteSwiftPackageReference "swift-protobuf" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1448,6 +1459,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 03BC11692AE56C2200C38FC4 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */;
 			productName = SDWebImageWebPCoder;
+		};
+		03D5A1C12F5A600100A1B2C3 /* libdatachannel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03D5A1C02F5A600100A1B2C3 /* XCLocalSwiftPackageReference "Packages/LibDataChannelPackage" */;
+			productName = libdatachannel;
 		};
 		03ECDF5C2B8E5F0B00BD920E /* WrappingHStack */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Moblin.xcodeproj/project.pbxproj
+++ b/Moblin.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		03BC116B2AE56C2200C38FC4 /* SDWebImageWebPCoder in Frameworks */ = {isa = PBXBuildFile; productRef = 03BC116A2AE56C2200C38FC4 /* SDWebImageWebPCoder */; };
 		03ECDF532B8E4E6000BD920E /* Moblin.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 03ECDF462B8E4E5E00BD920E /* Moblin.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		03ECDF5D2B8E5F0B00BD920E /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = 03ECDF5C2B8E5F0B00BD920E /* WrappingHStack */; };
+        03D5A1C22F5A600100A1B2C3 /* libdatachannel in Frameworks */ = {isa = PBXBuildFile; productRef = 03D5A1C12F5A600100A1B2C3 /* libdatachannel */; };
 		03F465EC2C441D1400630708 /* CrcSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 03F465EB2C441D1400630708 /* CrcSwift */; };
 		882D0C162DF76F5B0035BFAF /* BlackSharkLib in Frameworks */ = {isa = PBXBuildFile; productRef = 882D0C152DF76F5B0035BFAF /* BlackSharkLib */; };
 /* End PBXBuildFile section */

--- a/Moblin/Media/HaishinKit/Codec/Audio/AudioEncoderSettings.swift
+++ b/Moblin/Media/HaishinKit/Codec/Audio/AudioEncoderSettings.swift
@@ -34,7 +34,8 @@ struct AudioEncoderSettings {
                 )
             case .opus:
                 streamDescription = AudioStreamBasicDescription(
-                    mSampleRate: inSourceFormat.mSampleRate,
+                    // Opus RTP clock is fixed at 48 kHz; using 48k output avoids timestamp/rate drift.
+                    mSampleRate: 48_000,
                     mFormatID: kAudioFormatOpus,
                     mFormatFlags: 0,
                     mBytesPerPacket: 0,

--- a/Moblin/Media/Whip/WhipStream.swift
+++ b/Moblin/Media/Whip/WhipStream.swift
@@ -485,16 +485,28 @@ private struct WhipRtcTrackConfiguration {
     func addTrack(connection: Int32, streamId: String) throws -> WhipRtcTrack {
         let name = String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(16))
         let trackId = UUID().uuidString
+        let midPointer = strdup(mid)
+        let namePointer = strdup(name)
+        let msidPointer = strdup(streamId)
+        let trackIdPointer = strdup(trackId)
+        let profilePointer = profile.flatMap { strdup($0) }
+        defer {
+            free(midPointer)
+            free(namePointer)
+            free(msidPointer)
+            free(trackIdPointer)
+            free(profilePointer)
+        }
         var trackInit = rtcTrackInit(
             direction: RTC_DIRECTION_SENDONLY,
             codec: codec,
             payloadType: payloadType,
             ssrc: ssrc,
-            mid: strdup(mid),
-            name: strdup(name),
-            msid: strdup(streamId),
-            trackId: strdup(trackId),
-            profile: profile == nil ? nil : strdup(profile)
+            mid: midPointer.map { UnsafePointer($0) },
+            name: namePointer.map { UnsafePointer($0) },
+            msid: msidPointer.map { UnsafePointer($0) },
+            trackId: trackIdPointer.map { UnsafePointer($0) },
+            profile: profilePointer.map { UnsafePointer($0) }
         )
         let id = try whipCheck(rtcAddTrackEx(connection, &trackInit))
         return try WhipRtcTrack(id: id)
@@ -509,17 +521,22 @@ private final class WhipPeerConnection {
     var onSignalingStateChanged: ((rtcSignalingState) -> Void)?
     var onLocalCandidate: ((String, String) -> Void)?
 
-    init() throws {
+    init(stunUrls: [String]) throws {
         var configuration = rtcConfiguration()
         var createdId: Int32 = -1
-        if let stunServer = strdup("stun:stun.l.google.com:19302") {
-            var iceServers: [UnsafePointer<CChar>?] = [UnsafePointer(stunServer)]
+        let stunServers = stunUrls.compactMap { strdup($0) }
+        defer {
+            for stunServer in stunServers {
+                free(stunServer)
+            }
+        }
+        if !stunServers.isEmpty {
+            var iceServers: [UnsafePointer<CChar>?] = stunServers.map { UnsafePointer($0) }
             iceServers.withUnsafeMutableBufferPointer { buffer in
                 configuration.iceServers = buffer.baseAddress
                 configuration.iceServersCount = Int32(buffer.count)
                 createdId = rtcCreatePeerConnection(&configuration)
             }
-            free(stunServer)
         } else {
             createdId = rtcCreatePeerConnection(&configuration)
         }
@@ -646,15 +663,16 @@ final class WhipStream {
     private var stopping = false
     private var offerSent = false
     private var useNativeOpusPacketizer = false
+    private var activeSessionToken = UUID()
 
     init(processor: Processor, delegate: WhipStreamDelegate) {
         self.processor = processor
         self.delegate = delegate
     }
 
-    func start(url: String, bearerToken: String) {
+    func start(url: String, bearerToken: String, stunServers: [String]) {
         whipQueue.async {
-            self.startInternal(url: url, bearerToken: bearerToken)
+            self.startInternal(url: url, bearerToken: bearerToken, stunServers: stunServers)
         }
     }
 
@@ -670,12 +688,14 @@ final class WhipStream {
         }
     }
 
-    private func startInternal(url: String, bearerToken: String) {
+    private func startInternal(url: String, bearerToken: String, stunServers: [String]) {
         stopInternal(sendDelete: true)
         guard let endpointUrl = makeEndpointUrl(url: url) else {
             notifyDisconnected(reason: String(localized: "Malformed WHIP URL"))
             return
         }
+        let sessionToken = UUID()
+        activeSessionToken = sessionToken
         self.endpointUrl = endpointUrl
         authorizationHeader = makeAuthorizationHeader(token: bearerToken)
         totalByteCount = 0
@@ -683,8 +703,9 @@ final class WhipStream {
         stopping = false
         offerSent = false
         useNativeOpusPacketizer = false
+        let stunUrls = makeStunUrls(stunServers: stunServers)
         logger.info(
-            "whip: Start endpoint=\(endpointUrl.absoluteString) auth=\(authorizationHeader == nil ? "none" : "bearer")"
+            "whip: Start endpoint=\(endpointUrl.absoluteString) auth=\(authorizationHeader == nil ? "none" : "bearer") stun=\(stunUrls.count)"
         )
         let audioPacketizer = WhipOpusPacketizer(ssrc: Self.makeSsrc())
         let audioRtpPacketizer = WhipOpusRtpPacketizer(ssrc: audioPacketizer.ssrc, payloadType: whipOpusPayloadType)
@@ -693,19 +714,28 @@ final class WhipStream {
         self.audioRtpPacketizer = audioRtpPacketizer
         self.videoPacketizer = videoPacketizer
         do {
-            let peerConnection = try WhipPeerConnection()
+            let peerConnection = try WhipPeerConnection(stunUrls: stunUrls)
             peerConnection.onConnectionStateChanged = { [weak self] state in
                 whipQueue.async {
-                    self?.handleConnectionStateChanged(state: state)
+                    guard let self, self.isSessionActive(sessionToken) else {
+                        return
+                    }
+                    self.handleConnectionStateChanged(state: state)
                 }
             }
             peerConnection.onGatheringStateChanged = { [weak self] state in
                 whipQueue.async {
-                    self?.handleGatheringStateChanged(state: state)
+                    guard let self, self.isSessionActive(sessionToken) else {
+                        return
+                    }
+                    self.handleGatheringStateChanged(state: state, sessionToken: sessionToken)
                 }
             }
-            peerConnection.onIceStateChanged = { state in
+            peerConnection.onIceStateChanged = { [weak self] state in
                 whipQueue.async {
+                    guard let self, self.isSessionActive(sessionToken) else {
+                        return
+                    }
                     if state == .failed || state == .disconnected {
                         logger.info("whip: ICE state \(state.toString())")
                     }
@@ -734,7 +764,10 @@ final class WhipStream {
             try peerConnection.setLocalDescriptionOffer()
             // Fallback: if gathering callback is not delivered, send current local SDP after a short delay.
             whipQueue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-                self?.sendCurrentLocalOfferIfNeeded()
+                guard let self, self.isSessionActive(sessionToken) else {
+                    return
+                }
+                self.sendCurrentLocalOfferIfNeeded(sessionToken: sessionToken)
             }
         } catch {
             logger.info("whip: Start failed with error: \(error)")
@@ -742,17 +775,18 @@ final class WhipStream {
         }
     }
 
-    private func handleGatheringStateChanged(state: WhipGatheringState) {
+    private func handleGatheringStateChanged(state: WhipGatheringState, sessionToken: UUID) {
         switch state {
         case .complete:
-            sendCurrentLocalOfferIfNeeded()
+            sendCurrentLocalOfferIfNeeded(sessionToken: sessionToken)
         case .new, .inProgress:
             break
         }
     }
 
-    private func sendCurrentLocalOfferIfNeeded() {
+    private func sendCurrentLocalOfferIfNeeded(sessionToken: UUID) {
         guard !stopping,
+              isSessionActive(sessionToken),
               !offerSent,
               offerTask == nil,
               let endpointUrl,
@@ -766,7 +800,7 @@ final class WhipStream {
                 return
             }
             offerSent = true
-            sendOffer(endpointUrl: endpointUrl, offer: offer)
+            sendOffer(endpointUrl: endpointUrl, offer: offer, sessionToken: sessionToken)
         } catch {
             logger.info("whip: Failed to get local offer: \(error)")
         }
@@ -794,7 +828,7 @@ final class WhipStream {
         }
     }
 
-    private func sendOffer(endpointUrl: URL, offer: String) {
+    private func sendOffer(endpointUrl: URL, offer: String, sessionToken: UUID) {
         var request = URLRequest(url: endpointUrl)
         request.httpMethod = "POST"
         request.setContentType("application/sdp")
@@ -804,6 +838,9 @@ final class WhipStream {
         request.httpBody = offer.utf8Data
         offerTask = URLSession.shared.dataTask(with: request) { data, response, error in
             whipQueue.async {
+                guard self.isSessionActive(sessionToken) else {
+                    return
+                }
                 self.offerTask = nil
                 guard !self.stopping else {
                     return
@@ -851,6 +888,7 @@ final class WhipStream {
 
     private func stopInternal(sendDelete: Bool) {
         stopping = true
+        activeSessionToken = UUID()
         stopEncoding()
         offerTask?.cancel()
         offerTask = nil
@@ -871,6 +909,10 @@ final class WhipStream {
         connected = false
         offerSent = false
         stopping = false
+    }
+
+    private func isSessionActive(_ token: UUID) -> Bool {
+        return token == activeSessionToken
     }
 
     private func sendDeleteRequest(url: URL) {
@@ -950,6 +992,28 @@ final class WhipStream {
             return token
         }
         return "Bearer \(token)"
+    }
+
+    private func makeStunUrls(stunServers: [String]) -> [String] {
+        let customStunUrls = stunServers
+            .map { $0.trim() }
+            .filter { !$0.isEmpty }
+            .map { server in
+                let serverLowercased = server.lowercased()
+                if serverLowercased.hasPrefix("stun:") || serverLowercased.hasPrefix("stuns:") {
+                    return server
+                } else {
+                    return "stun:\(server)"
+                }
+            }
+        if !customStunUrls.isEmpty {
+            return customStunUrls
+        }
+        return [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun.cloudflare.com:3478",
+        ]
     }
 
     private static func makeSsrc() -> UInt32 {

--- a/Moblin/Media/Whip/WhipStream.swift
+++ b/Moblin/Media/Whip/WhipStream.swift
@@ -1,0 +1,1029 @@
+import AVFoundation
+import Foundation
+import libdatachannel
+
+private let whipQueue = DispatchQueue(label: "com.eerimoq.Moblin.whip")
+private let whipH264PayloadType: UInt8 = 98
+private let whipOpusPayloadType: UInt8 = 111
+private let whipRtpMtu = 1200
+
+private enum WhipRtcError: Error {
+    case rtc(Int32)
+}
+
+@discardableResult
+private func whipCheck(_ result: Int32) throws -> Int32 {
+    guard result >= 0 else {
+        throw WhipRtcError.rtc(result)
+    }
+    return result
+}
+
+private func whipGetString(_ lambda: (UnsafeMutablePointer<CChar>?, Int32) -> Int32) throws -> String {
+    let size = try whipCheck(lambda(nil, 0))
+    var buffer = [CChar](repeating: 0, count: Int(size))
+    _ = try whipCheck(lambda(&buffer, Int32(size)))
+    return String(cString: buffer)
+}
+
+private enum WhipConnectionState {
+    case new
+    case connecting
+    case connected
+    case disconnected
+    case failed
+    case closed
+
+    init?(cValue: rtcState) {
+        switch cValue {
+        case RTC_NEW:
+            self = .new
+        case RTC_CONNECTING:
+            self = .connecting
+        case RTC_CONNECTED:
+            self = .connected
+        case RTC_DISCONNECTED:
+            self = .disconnected
+        case RTC_FAILED:
+            self = .failed
+        case RTC_CLOSED:
+            self = .closed
+        default:
+            return nil
+        }
+    }
+
+    func toString() -> String {
+        switch self {
+        case .new:
+            return "new"
+        case .connecting:
+            return "connecting"
+        case .connected:
+            return "connected"
+        case .disconnected:
+            return "disconnected"
+        case .failed:
+            return "failed"
+        case .closed:
+            return "closed"
+        }
+    }
+}
+
+private enum WhipGatheringState {
+    case new
+    case inProgress
+    case complete
+
+    init?(cValue: rtcGatheringState) {
+        switch cValue {
+        case RTC_GATHERING_NEW:
+            self = .new
+        case RTC_GATHERING_INPROGRESS:
+            self = .inProgress
+        case RTC_GATHERING_COMPLETE:
+            self = .complete
+        default:
+            return nil
+        }
+    }
+
+    func toString() -> String {
+        switch self {
+        case .new:
+            return "new"
+        case .inProgress:
+            return "in-progress"
+        case .complete:
+            return "complete"
+        }
+    }
+}
+
+private enum WhipTrackState {
+    case connecting
+    case open
+    case closed
+}
+
+private enum WhipIceState {
+    case new
+    case checking
+    case connected
+    case completed
+    case failed
+    case disconnected
+    case closed
+
+    init?(cValue: rtcIceState) {
+        switch cValue {
+        case RTC_ICE_NEW:
+            self = .new
+        case RTC_ICE_CHECKING:
+            self = .checking
+        case RTC_ICE_CONNECTED:
+            self = .connected
+        case RTC_ICE_COMPLETED:
+            self = .completed
+        case RTC_ICE_FAILED:
+            self = .failed
+        case RTC_ICE_DISCONNECTED:
+            self = .disconnected
+        case RTC_ICE_CLOSED:
+            self = .closed
+        default:
+            return nil
+        }
+    }
+
+    func toString() -> String {
+        switch self {
+        case .new:
+            return "new"
+        case .checking:
+            return "checking"
+        case .connected:
+            return "connected"
+        case .completed:
+            return "completed"
+        case .failed:
+            return "failed"
+        case .disconnected:
+            return "disconnected"
+        case .closed:
+            return "closed"
+        }
+    }
+}
+
+private struct WhipRtpPacket {
+    let marker: Bool
+    let payloadType: UInt8
+    let sequenceNumber: UInt16
+    let timestamp: UInt32
+    let ssrc: UInt32
+    let payload: Data
+
+    func data() -> Data {
+        var data = Data(capacity: 12 + payload.count)
+        data.append(0x80)
+        data.append((marker ? 0x80 : 0x00) | (payloadType & 0x7F))
+        data.append(contentsOf: [
+            UInt8((sequenceNumber >> 8) & 0xFF),
+            UInt8(sequenceNumber & 0xFF),
+        ])
+        data.append(contentsOf: [
+            UInt8((timestamp >> 24) & 0xFF),
+            UInt8((timestamp >> 16) & 0xFF),
+            UInt8((timestamp >> 8) & 0xFF),
+            UInt8(timestamp & 0xFF),
+        ])
+        data.append(contentsOf: [
+            UInt8((ssrc >> 24) & 0xFF),
+            UInt8((ssrc >> 16) & 0xFF),
+            UInt8((ssrc >> 8) & 0xFF),
+            UInt8(ssrc & 0xFF),
+        ])
+        data.append(payload)
+        return data
+    }
+}
+
+private struct WhipRtpTimestamp {
+    private let rate: Double
+    private var startedAt: Double?
+
+    init(rate: Double) {
+        self.rate = rate
+    }
+
+    mutating func convert(_ time: CMTime) -> UInt32 {
+        let seconds = time.seconds
+        if startedAt == nil {
+            startedAt = seconds
+        }
+        let timestamp = UInt64(max((seconds - (startedAt ?? seconds)) * rate, 0))
+        return UInt32(timestamp & 0xFFFF_FFFF)
+    }
+}
+
+private final class WhipH264Packetizer {
+    let ssrc: UInt32
+    private let payloadType: UInt8
+    private var sequenceNumber: UInt16 = 0
+    private var timestamp = WhipRtpTimestamp(rate: 90_000)
+    private var sps: Data?
+    private var pps: Data?
+
+    init(ssrc: UInt32, payloadType: UInt8) {
+        self.ssrc = ssrc
+        self.payloadType = payloadType
+    }
+
+    func setParameterSets(sps: Data?, pps: Data?) {
+        self.sps = sps
+        self.pps = pps
+    }
+
+    func packetize(sampleBuffer: CMSampleBuffer) -> [Data] {
+        var nalUnits = extractNalUnits(sampleBuffer: sampleBuffer)
+        guard !nalUnits.isEmpty else {
+            return []
+        }
+        if sampleBuffer.getIsSync() {
+            if let sps {
+                nalUnits.insert(sps, at: 0)
+            }
+            if let pps {
+                nalUnits.insert(pps, at: min(1, nalUnits.count))
+            }
+        }
+        let packetTimestamp = timestamp.convert(sampleBuffer.presentationTimeStamp)
+        var packets: [Data] = []
+        for (index, nalUnit) in nalUnits.enumerated() {
+            let isLastNal = index == nalUnits.count - 1
+            if nalUnit.count <= whipRtpMtu {
+                let packet = WhipRtpPacket(
+                    marker: isLastNal,
+                    payloadType: payloadType,
+                    sequenceNumber: sequenceNumber,
+                    timestamp: packetTimestamp,
+                    ssrc: ssrc,
+                    payload: nalUnit
+                )
+                packets.append(packet.data())
+                sequenceNumber &+= 1
+            } else {
+                let nalHeader = nalUnit[0]
+                let fuIndicator = (nalHeader & 0xE0) | 28
+                let nalType = nalHeader & 0x1F
+                var offset = 1
+                var first = true
+                while offset < nalUnit.count {
+                    let chunkSize = min(whipRtpMtu - 2, nalUnit.count - offset)
+                    var fuHeader = nalType
+                    if first {
+                        fuHeader |= 0x80
+                    }
+                    let isFinalFragment = offset + chunkSize >= nalUnit.count
+                    if isFinalFragment {
+                        fuHeader |= 0x40
+                    }
+                    var payload = Data([fuIndicator, fuHeader])
+                    payload.append(contentsOf: nalUnit[offset ..< offset + chunkSize])
+                    let packet = WhipRtpPacket(
+                        marker: isLastNal && isFinalFragment,
+                        payloadType: payloadType,
+                        sequenceNumber: sequenceNumber,
+                        timestamp: packetTimestamp,
+                        ssrc: ssrc,
+                        payload: payload
+                    )
+                    packets.append(packet.data())
+                    sequenceNumber &+= 1
+                    offset += chunkSize
+                    first = false
+                }
+            }
+        }
+        return packets
+    }
+
+    private func extractNalUnits(sampleBuffer: CMSampleBuffer) -> [Data] {
+        guard let (buffer, length) = sampleBuffer.dataBuffer?.getDataPointer() else {
+            return []
+        }
+        let data = Data(bytes: buffer, count: length)
+        var nalUnits: [Data] = []
+        var offset = 0
+        while offset + 4 <= data.count {
+            let nalLength = Int(data.getFourBytesBe(offset: offset))
+            offset += 4
+            guard nalLength > 0, offset + nalLength <= data.count else {
+                break
+            }
+            nalUnits.append(data.subdata(in: offset ..< offset + nalLength))
+            offset += nalLength
+        }
+        return nalUnits
+    }
+}
+
+private final class WhipOpusPacketizer {
+    let ssrc: UInt32
+
+    init(ssrc: UInt32) {
+        self.ssrc = ssrc
+    }
+
+    func packetize(buffer: AVAudioCompressedBuffer, presentationTimeStamp: CMTime) -> [Data] {
+        _ = presentationTimeStamp
+        guard buffer.byteLength > 0 else {
+            return []
+        }
+
+        let allData = Data(bytes: buffer.data, count: Int(buffer.byteLength))
+        guard buffer.packetCount > 0, let descriptions = buffer.packetDescriptions else {
+            return [allData]
+        }
+
+        var packets: [Data] = []
+        packets.reserveCapacity(Int(buffer.packetCount))
+        for index in 0 ..< Int(buffer.packetCount) {
+            let description = descriptions[index]
+            let offset = Int(description.mStartOffset)
+            let size = Int(description.mDataByteSize)
+            guard size > 0, offset >= 0, offset + size <= allData.count else {
+                continue
+            }
+            packets.append(allData.subdata(in: offset ..< offset + size))
+        }
+        return packets.isEmpty ? [allData] : packets
+    }
+}
+
+private final class WhipOpusRtpPacketizer {
+    private let ssrc: UInt32
+    private let payloadType: UInt8
+    private var sequenceNumber: UInt16 = 0
+    private var timestamp: UInt32 = 0
+
+    init(ssrc: UInt32, payloadType: UInt8) {
+        self.ssrc = ssrc
+        self.payloadType = payloadType
+    }
+
+    func packetize(payload: Data) -> Data {
+        let packet = WhipRtpPacket(
+            marker: false,
+            payloadType: payloadType,
+            sequenceNumber: sequenceNumber,
+            timestamp: timestamp,
+            ssrc: ssrc,
+            payload: payload
+        )
+        sequenceNumber &+= 1
+        timestamp &+= 960
+        return packet.data()
+    }
+}
+
+private final class WhipRtcTrack {
+    let id: Int32
+    var onStateChanged: ((WhipTrackState) -> Void)?
+    private(set) var state: WhipTrackState = .connecting {
+        didSet {
+            guard state != oldValue else {
+                return
+            }
+            onStateChanged?(state)
+        }
+    }
+
+    init(id: Int32) throws {
+        self.id = id
+        try whipCheck(id)
+        do {
+            rtcSetUserPointer(id, Unmanaged.passUnretained(self).toOpaque())
+            try whipCheck(rtcSetOpenCallback(id) { _, pointer in
+                guard let pointer else {
+                    return
+                }
+                Unmanaged<WhipRtcTrack>.fromOpaque(pointer).takeUnretainedValue().state = .open
+            })
+            try whipCheck(rtcSetClosedCallback(id) { _, pointer in
+                guard let pointer else {
+                    return
+                }
+                Unmanaged<WhipRtcTrack>.fromOpaque(pointer).takeUnretainedValue().state = .closed
+            })
+            try whipCheck(rtcSetErrorCallback(id) { _, error, pointer in
+                guard let pointer else {
+                    return
+                }
+                let track = Unmanaged<WhipRtcTrack>.fromOpaque(pointer).takeUnretainedValue()
+                track.state = .closed
+                if let error {
+                    logger.info("whip: Track error: \(String(cString: error))")
+                }
+            })
+        } catch {
+            rtcDeleteTrack(id)
+            throw error
+        }
+    }
+
+    deinit {
+        rtcDeleteTrack(id)
+    }
+
+    func send(packet: Data) -> Bool {
+        guard state == .open else {
+            return false
+        }
+        let result = packet.withUnsafeBytes { pointer in
+            rtcSendMessage(id, pointer.bindMemory(to: CChar.self).baseAddress, Int32(packet.count))
+        }
+        return result >= 0
+    }
+
+    func setOpusPacketizer(ssrc: UInt32, payloadType: UInt8) -> Bool {
+        var packetizerInit = rtcPacketizerInit(
+            ssrc: ssrc,
+            cname: nil,
+            payloadType: payloadType,
+            clockRate: 48_000,
+            sequenceNumber: UInt16.random(in: UInt16.min ... UInt16.max),
+            timestamp: UInt32.random(in: UInt32.min ... UInt32.max),
+            maxFragmentSize: 0,
+            nalSeparator: RTC_NAL_SEPARATOR_LENGTH,
+            obuPacketization: RTC_OBU_PACKETIZED_OBU,
+            playoutDelayId: 0,
+            playoutDelayMin: 0,
+            playoutDelayMax: 0,
+            colorSpaceId: 0,
+            colorChromaSitingHorz: 0,
+            colorChromaSitingVert: 0,
+            colorRange: 0,
+            colorPrimaries: 0,
+            colorTransfer: 0,
+            colorMatrix: 0
+        )
+        let result = rtcSetOpusPacketizer(id, &packetizerInit)
+        if result < 0 {
+            logger.info("whip: Native Opus packetizer unavailable (result=\(result)), using RTP fallback")
+            return false
+        }
+        return true
+    }
+}
+
+private struct WhipRtcTrackConfiguration {
+    let codec: rtcCodec
+    let payloadType: Int32
+    let ssrc: UInt32
+    let mid: String
+    let profile: String?
+
+    static func makeAudio(ssrc: UInt32) -> Self {
+        return .init(codec: RTC_CODEC_OPUS,
+                     payloadType: Int32(whipOpusPayloadType),
+                     ssrc: ssrc,
+                     mid: "0",
+                     profile: "minptime=10;useinbandfec=1;stereo=1;sprop-stereo=1")
+    }
+
+    static func makeVideo(ssrc: UInt32) -> Self {
+        return .init(codec: RTC_CODEC_H264,
+                     payloadType: Int32(whipH264PayloadType),
+                     ssrc: ssrc,
+                     mid: "1",
+                     profile: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f")
+    }
+
+    func addTrack(connection: Int32, streamId: String) throws -> WhipRtcTrack {
+        let name = String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(16))
+        let trackId = UUID().uuidString
+        var trackInit = rtcTrackInit(
+            direction: RTC_DIRECTION_SENDONLY,
+            codec: codec,
+            payloadType: payloadType,
+            ssrc: ssrc,
+            mid: strdup(mid),
+            name: strdup(name),
+            msid: strdup(streamId),
+            trackId: strdup(trackId),
+            profile: profile == nil ? nil : strdup(profile)
+        )
+        let id = try whipCheck(rtcAddTrackEx(connection, &trackInit))
+        return try WhipRtcTrack(id: id)
+    }
+}
+
+private final class WhipPeerConnection {
+    let id: Int32
+    var onConnectionStateChanged: ((WhipConnectionState) -> Void)?
+    var onGatheringStateChanged: ((WhipGatheringState) -> Void)?
+    var onIceStateChanged: ((WhipIceState) -> Void)?
+    var onSignalingStateChanged: ((rtcSignalingState) -> Void)?
+    var onLocalCandidate: ((String, String) -> Void)?
+
+    init() throws {
+        var configuration = rtcConfiguration()
+        var createdId: Int32 = -1
+        if let stunServer = strdup("stun:stun.l.google.com:19302") {
+            var iceServers: [UnsafePointer<CChar>?] = [UnsafePointer(stunServer)]
+            iceServers.withUnsafeMutableBufferPointer { buffer in
+                configuration.iceServers = buffer.baseAddress
+                configuration.iceServersCount = Int32(buffer.count)
+                createdId = rtcCreatePeerConnection(&configuration)
+            }
+            free(stunServer)
+        } else {
+            createdId = rtcCreatePeerConnection(&configuration)
+        }
+        id = createdId
+        try whipCheck(id)
+        do {
+            rtcSetUserPointer(id, Unmanaged.passUnretained(self).toOpaque())
+            try whipCheck(rtcSetStateChangeCallback(id) { _, state, pointer in
+                guard let pointer,
+                      let state = WhipConnectionState(cValue: state)
+                else {
+                    return
+                }
+                Unmanaged<WhipPeerConnection>.fromOpaque(pointer)
+                    .takeUnretainedValue()
+                    .onConnectionStateChanged?(state)
+            })
+            try whipCheck(rtcSetLocalDescriptionCallback(id) { _, _, _, _ in })
+            try whipCheck(rtcSetLocalCandidateCallback(id) { _, candidate, mid, pointer in
+                guard let pointer else {
+                    return
+                }
+                let candidate = candidate.map { String(cString: $0) } ?? ""
+                let mid = mid.map { String(cString: $0) } ?? ""
+                Unmanaged<WhipPeerConnection>.fromOpaque(pointer)
+                    .takeUnretainedValue()
+                    .onLocalCandidate?(candidate, mid)
+            })
+            try whipCheck(rtcSetSignalingStateChangeCallback(id) { _, state, pointer in
+                guard let pointer else {
+                    return
+                }
+                Unmanaged<WhipPeerConnection>.fromOpaque(pointer)
+                    .takeUnretainedValue()
+                    .onSignalingStateChanged?(state)
+            })
+            try whipCheck(rtcSetIceStateChangeCallback(id) { _, state, pointer in
+                guard let pointer,
+                      let state = WhipIceState(cValue: state)
+                else {
+                    return
+                }
+                Unmanaged<WhipPeerConnection>.fromOpaque(pointer)
+                    .takeUnretainedValue()
+                    .onIceStateChanged?(state)
+            })
+            try whipCheck(rtcSetGatheringStateChangeCallback(id) { _, state, pointer in
+                guard let pointer,
+                      let state = WhipGatheringState(cValue: state)
+                else {
+                    return
+                }
+                Unmanaged<WhipPeerConnection>.fromOpaque(pointer)
+                    .takeUnretainedValue()
+                    .onGatheringStateChanged?(state)
+            })
+        } catch {
+            rtcDeletePeerConnection(id)
+            throw error
+        }
+    }
+
+    deinit {
+        rtcDeletePeerConnection(id)
+    }
+
+    func addTrack(configuration: WhipRtcTrackConfiguration, streamId: String) throws -> WhipRtcTrack {
+        return try configuration.addTrack(connection: id, streamId: streamId)
+    }
+
+    func setLocalDescriptionOffer() throws {
+        _ = try "offer".withCString { cType in
+            try whipCheck(rtcSetLocalDescription(id, cType))
+        }
+    }
+
+    func createOffer() throws -> String {
+        return try whipGetString { buffer, size in
+            rtcCreateOffer(id, buffer, size)
+        }
+    }
+
+    func getLocalDescription() throws -> String {
+        return try whipGetString { buffer, size in
+            rtcGetLocalDescription(id, buffer, size)
+        }
+    }
+
+    func setRemoteAnswer(_ sdp: String) throws {
+        _ = try sdp.withCString { cSdp in
+            _ = try "answer".withCString { cType in
+                try whipCheck(rtcSetRemoteDescription(id, cSdp, cType))
+            }
+        }
+    }
+
+    func close() {
+        _ = rtcClosePeerConnection(id)
+    }
+}
+
+protocol WhipStreamDelegate: AnyObject {
+    func whipStreamOnConnected()
+    func whipStreamOnDisconnected(reason: String)
+}
+
+final class WhipStream {
+    private let processor: Processor
+    private weak var delegate: WhipStreamDelegate?
+    private var peerConnection: WhipPeerConnection?
+    private var videoTrack: WhipRtcTrack?
+    private var audioTrack: WhipRtcTrack?
+    private var videoPacketizer: WhipH264Packetizer?
+    private var audioPacketizer: WhipOpusPacketizer?
+    private var audioRtpPacketizer: WhipOpusRtpPacketizer?
+    private var totalByteCount: Int64 = 0
+    private var offerTask: URLSessionTask?
+    private var deleteTask: URLSessionTask?
+    private var sessionUrl: URL?
+    private var endpointUrl: URL?
+    private var authorizationHeader: String?
+    private var encoding = false
+    private var connected = false
+    private var stopping = false
+    private var offerSent = false
+    private var useNativeOpusPacketizer = false
+
+    init(processor: Processor, delegate: WhipStreamDelegate) {
+        self.processor = processor
+        self.delegate = delegate
+    }
+
+    func start(url: String, bearerToken: String) {
+        whipQueue.async {
+            self.startInternal(url: url, bearerToken: bearerToken)
+        }
+    }
+
+    func stop() {
+        whipQueue.async {
+            self.stopInternal(sendDelete: true)
+        }
+    }
+
+    func getTotalByteCount() -> Int64 {
+        return whipQueue.sync {
+            totalByteCount
+        }
+    }
+
+    private func startInternal(url: String, bearerToken: String) {
+        stopInternal(sendDelete: true)
+        guard let endpointUrl = makeEndpointUrl(url: url) else {
+            notifyDisconnected(reason: String(localized: "Malformed WHIP URL"))
+            return
+        }
+        self.endpointUrl = endpointUrl
+        authorizationHeader = makeAuthorizationHeader(token: bearerToken)
+        totalByteCount = 0
+        connected = false
+        stopping = false
+        offerSent = false
+        useNativeOpusPacketizer = false
+        logger.info(
+            "whip: Start endpoint=\(endpointUrl.absoluteString) auth=\(authorizationHeader == nil ? "none" : "bearer")"
+        )
+        let audioPacketizer = WhipOpusPacketizer(ssrc: Self.makeSsrc())
+        let audioRtpPacketizer = WhipOpusRtpPacketizer(ssrc: audioPacketizer.ssrc, payloadType: whipOpusPayloadType)
+        let videoPacketizer = WhipH264Packetizer(ssrc: Self.makeSsrc(), payloadType: whipH264PayloadType)
+        self.audioPacketizer = audioPacketizer
+        self.audioRtpPacketizer = audioRtpPacketizer
+        self.videoPacketizer = videoPacketizer
+        do {
+            let peerConnection = try WhipPeerConnection()
+            peerConnection.onConnectionStateChanged = { [weak self] state in
+                whipQueue.async {
+                    self?.handleConnectionStateChanged(state: state)
+                }
+            }
+            peerConnection.onGatheringStateChanged = { [weak self] state in
+                whipQueue.async {
+                    self?.handleGatheringStateChanged(state: state)
+                }
+            }
+            peerConnection.onIceStateChanged = { state in
+                whipQueue.async {
+                    if state == .failed || state == .disconnected {
+                        logger.info("whip: ICE state \(state.toString())")
+                    }
+                }
+            }
+            peerConnection.onSignalingStateChanged = { _ in }
+            peerConnection.onLocalCandidate = { _, _ in }
+            let streamId = UUID().uuidString
+            let audioTrack = try peerConnection.addTrack(
+                configuration: .makeAudio(ssrc: audioPacketizer.ssrc),
+                streamId: streamId
+            )
+            let videoTrack = try peerConnection.addTrack(
+                configuration: .makeVideo(ssrc: videoPacketizer.ssrc),
+                streamId: streamId
+            )
+            useNativeOpusPacketizer = audioTrack.setOpusPacketizer(
+                ssrc: audioPacketizer.ssrc,
+                payloadType: whipOpusPayloadType
+            )
+            audioTrack.onStateChanged = { _ in }
+            videoTrack.onStateChanged = { _ in }
+            self.audioTrack = audioTrack
+            self.videoTrack = videoTrack
+            self.peerConnection = peerConnection
+            try peerConnection.setLocalDescriptionOffer()
+            // Fallback: if gathering callback is not delivered, send current local SDP after a short delay.
+            whipQueue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                self?.sendCurrentLocalOfferIfNeeded()
+            }
+        } catch {
+            logger.info("whip: Start failed with error: \(error)")
+            notifyDisconnected(reason: String(localized: "WHIP connect failed"))
+        }
+    }
+
+    private func handleGatheringStateChanged(state: WhipGatheringState) {
+        switch state {
+        case .complete:
+            sendCurrentLocalOfferIfNeeded()
+        case .new, .inProgress:
+            break
+        }
+    }
+
+    private func sendCurrentLocalOfferIfNeeded() {
+        guard !stopping,
+              !offerSent,
+              offerTask == nil,
+              let endpointUrl,
+              let peerConnection
+        else {
+            return
+        }
+        do {
+            let offer = try peerConnection.getLocalDescription()
+            guard !offer.isEmpty else {
+                return
+            }
+            offerSent = true
+            sendOffer(endpointUrl: endpointUrl, offer: offer)
+        } catch {
+            logger.info("whip: Failed to get local offer: \(error)")
+        }
+    }
+
+    private func handleConnectionStateChanged(state: WhipConnectionState) {
+        logger.info("whip: Connection state \(state.toString())")
+        switch state {
+        case .connected:
+            guard !connected, !stopping else {
+                return
+            }
+            connected = true
+            startEncoding()
+            notifyConnected()
+        case .disconnected, .failed, .closed:
+            guard !stopping else {
+                return
+            }
+            let reason = String(localized: "WHIP disconnected (\(state.toString()))")
+            stopInternal(sendDelete: true)
+            notifyDisconnected(reason: reason)
+        case .new, .connecting:
+            break
+        }
+    }
+
+    private func sendOffer(endpointUrl: URL, offer: String) {
+        var request = URLRequest(url: endpointUrl)
+        request.httpMethod = "POST"
+        request.setContentType("application/sdp")
+        if let authorizationHeader {
+            request.setAuthorization(authorizationHeader)
+        }
+        request.httpBody = offer.utf8Data
+        offerTask = URLSession.shared.dataTask(with: request) { data, response, error in
+            whipQueue.async {
+                self.offerTask = nil
+                guard !self.stopping else {
+                    return
+                }
+                if let error {
+                    logger.info("whip: Offer request failed with error: \(error)")
+                    self.stopInternal(sendDelete: true)
+                    self.notifyDisconnected(reason: String(localized: "WHIP offer failed"))
+                    return
+                }
+                guard let response = response as? HTTPURLResponse else {
+                    logger.info("whip: Offer response was not HTTP")
+                    self.stopInternal(sendDelete: true)
+                    self.notifyDisconnected(reason: String(localized: "WHIP bad server response"))
+                    return
+                }
+                logger.info("whip: Offer response status=\(response.statusCode)")
+                guard (200 ... 299).contains(response.statusCode) else {
+                    self.stopInternal(sendDelete: true)
+                    self.notifyDisconnected(
+                        reason: String(localized: "WHIP server returned \(response.statusCode)")
+                    )
+                    return
+                }
+                if let locationHeader = response.value(forHTTPHeaderField: "Location") {
+                    self.sessionUrl = URL(string: locationHeader, relativeTo: endpointUrl)?.absoluteURL
+                    logger.info("whip: Session location=\(self.sessionUrl?.absoluteString ?? locationHeader)")
+                }
+                guard let data, let answer = String(data: data, encoding: .utf8) else {
+                    self.stopInternal(sendDelete: true)
+                    self.notifyDisconnected(reason: String(localized: "WHIP answer missing"))
+                    return
+                }
+                do {
+                    try self.peerConnection?.setRemoteAnswer(answer)
+                } catch {
+                    logger.info("whip: Failed to set remote answer: \(error)")
+                    self.stopInternal(sendDelete: true)
+                    self.notifyDisconnected(reason: String(localized: "WHIP answer rejected"))
+                }
+            }
+        }
+        offerTask?.resume()
+    }
+
+    private func stopInternal(sendDelete: Bool) {
+        stopping = true
+        stopEncoding()
+        offerTask?.cancel()
+        offerTask = nil
+        deleteTask?.cancel()
+        deleteTask = nil
+        if sendDelete, let sessionUrl {
+            sendDeleteRequest(url: sessionUrl)
+        }
+        sessionUrl = nil
+        endpointUrl = nil
+        peerConnection?.close()
+        peerConnection = nil
+        videoTrack = nil
+        audioTrack = nil
+        videoPacketizer = nil
+        audioPacketizer = nil
+        audioRtpPacketizer = nil
+        connected = false
+        offerSent = false
+        stopping = false
+    }
+
+    private func sendDeleteRequest(url: URL) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setContentType("application/sdp")
+        if let authorizationHeader {
+            request.setAuthorization(authorizationHeader)
+        }
+        deleteTask = URLSession.shared.dataTask(with: request) { _, response, error in
+            whipQueue.async {
+                if let error {
+                    logger.info("whip: DELETE failed with error: \(error)")
+                    return
+                }
+                _ = response
+            }
+        }
+        deleteTask?.resume()
+    }
+
+    private func startEncoding() {
+        guard !encoding else {
+            return
+        }
+        encoding = true
+        processorControlQueue.async {
+            self.processor.startEncoding(self)
+        }
+    }
+
+    private func stopEncoding() {
+        guard encoding else {
+            return
+        }
+        encoding = false
+        processorControlQueue.async {
+            self.processor.stopEncoding(self)
+        }
+    }
+
+    private func notifyConnected() {
+        DispatchQueue.main.async {
+            self.delegate?.whipStreamOnConnected()
+        }
+    }
+
+    private func notifyDisconnected(reason: String) {
+        DispatchQueue.main.async {
+            self.delegate?.whipStreamOnDisconnected(reason: reason)
+        }
+    }
+
+    private func makeEndpointUrl(url: String) -> URL? {
+        guard var components = URLComponents(string: url) else {
+            return nil
+        }
+        switch components.scheme?.lowercased() {
+        case "whip":
+            components.scheme = "http"
+        case "whips":
+            components.scheme = "https"
+        case "http", "https":
+            break
+        default:
+            return nil
+        }
+        return components.url
+    }
+
+    private func makeAuthorizationHeader(token: String) -> String? {
+        let token = token.trim()
+        guard !token.isEmpty else {
+            return nil
+        }
+        if token.lowercased().hasPrefix("bearer ") {
+            return token
+        }
+        return "Bearer \(token)"
+    }
+
+    private static func makeSsrc() -> UInt32 {
+        var ssrc: UInt32 = 0
+        while ssrc == 0 {
+            ssrc = UInt32.random(in: UInt32.min ... UInt32.max)
+        }
+        return ssrc
+    }
+
+}
+
+extension WhipStream: AudioEncoderDelegate {
+    func audioEncoderOutputFormat(_ format: AVAudioFormat) {
+        guard format.formatDescription.audioStreamBasicDescription?.mFormatID == kAudioFormatOpus else {
+            logger.info("whip: Expected Opus audio for WHIP")
+            return
+        }
+    }
+
+    func audioEncoderOutputBuffer(_ buffer: AVAudioCompressedBuffer, _ presentationTimeStamp: CMTime) {
+        whipQueue.async {
+            guard self.connected,
+                  let packets = self.audioPacketizer?.packetize(
+                      buffer: buffer,
+                      presentationTimeStamp: presentationTimeStamp
+                  )
+            else {
+                return
+            }
+            for packet in packets {
+                let outgoingPacket: Data
+                if self.useNativeOpusPacketizer {
+                    outgoingPacket = packet
+                } else if let rtpPacketizer = self.audioRtpPacketizer {
+                    outgoingPacket = rtpPacketizer.packetize(payload: packet)
+                } else {
+                    continue
+                }
+                if self.audioTrack?.send(packet: outgoingPacket) == true {
+                    self.totalByteCount += Int64(outgoingPacket.count)
+                }
+            }
+        }
+    }
+}
+
+extension WhipStream: VideoEncoderDelegate {
+    func videoEncoderOutputFormat(_: VideoEncoder, _ formatDescription: CMFormatDescription) {
+        whipQueue.async {
+            if let config = MpegTsVideoConfigAvc(formatDescription: formatDescription) {
+                self.videoPacketizer?.setParameterSets(
+                    sps: config.sequenceParameterSet,
+                    pps: config.pictureParameterSet
+                )
+            }
+        }
+    }
+
+    func videoEncoderOutputSampleBuffer(_: VideoEncoder,
+                                        _ sampleBuffer: CMSampleBuffer,
+                                        _ decodeTimeStampOffset: CMTime)
+    {
+        whipQueue.async {
+            guard self.connected,
+                  let packets = self.videoPacketizer?.packetize(sampleBuffer: sampleBuffer)
+            else {
+                return
+            }
+            for packet in packets {
+                if self.videoTrack?.send(packet: packet) == true {
+                    self.totalByteCount += Int64(packet.count)
+                }
+            }
+        }
+    }
+}

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -23,6 +23,8 @@ protocol MediaDelegate: AnyObject {
     func mediaOnRtmpDestinationDisconnected(_ destination: String)
     func mediaOnRistConnected()
     func mediaOnRistDisconnected()
+    func mediaOnWhipConnected()
+    func mediaOnWhipDisconnected(_ reason: String)
     func mediaOnAudioMuteChange()
     func mediaOnAudioBuffer(_ sampleBuffer: CMSampleBuffer)
     func mediaOnLowFpsImage(_ lowFpsImage: Data?, _ frameNumber: UInt64)
@@ -53,6 +55,7 @@ final class Media: NSObject {
     private var srtStreamNew: SrtStreamMoblin?
     private var srtStreamOld: SrtStreamOfficial?
     private var ristStream: RistStream?
+    private var whipStream: WhipStream?
     private var srtlaClient: SrtlaClient?
     private var processor: Processor?
     private var srtTotalByteCount: Int64 = 0
@@ -101,10 +104,12 @@ final class Media: NSObject {
         srtStopStream()
         rtmpStopStream()
         ristStopStream()
+        whipStopStream()
         rtmpStreams.removeAll()
         srtStreamNew = nil
         srtStreamOld = nil
         ristStream = nil
+        whipStream = nil
         processor = nil
     }
 
@@ -120,6 +125,7 @@ final class Media: NSObject {
         srtStopStream()
         rtmpStopStream()
         ristStopStream()
+        whipStopStream()
         let processor = Processor()
         switch proto {
         case .rtmp:
@@ -138,6 +144,7 @@ final class Media: NSObject {
             srtStreamNew = nil
             srtStreamOld = nil
             ristStream = nil
+            whipStream = nil
         case .srt:
             switch srtImplementation {
             case .moblin:
@@ -157,10 +164,18 @@ final class Media: NSObject {
             }
             rtmpStreams.removeAll()
             ristStream = nil
+            whipStream = nil
         case .rist:
             ristStream = RistStream(processor: processor, timecodesEnabled: timecodesEnabled, delegate: self)
             srtStreamNew = nil
             srtStreamOld = nil
+            rtmpStreams.removeAll()
+            whipStream = nil
+        case .whip:
+            whipStream = WhipStream(processor: processor, delegate: self)
+            srtStreamNew = nil
+            srtStreamOld = nil
+            ristStream = nil
             rtmpStreams.removeAll()
         }
         self.processor = processor
@@ -503,6 +518,8 @@ final class Media: NSObject {
             return 8 * srtTransportBitrate
         } else if ristStream != nil {
             return Int64(ristStream?.getSpeed() ?? 0)
+        } else if whipStream != nil {
+            return 0
         } else {
             return 0
         }
@@ -515,6 +532,9 @@ final class Media: NSObject {
         }
         if isSrtStreamActive() {
             return srtTotalByteCount
+        }
+        if let whipStream {
+            return whipStream.getTotalByteCount()
         }
         return total
     }
@@ -605,6 +625,15 @@ final class Media: NSObject {
 
     func ristStopStream() {
         ristStream?.stop()
+    }
+
+    func whipStartStream(url: String, bearerToken: String) {
+        adaptiveBitrate = nil
+        whipStream?.start(url: url, bearerToken: bearerToken)
+    }
+
+    func whipStopStream() {
+        whipStream?.stop()
     }
 
     func setTorch(on: Bool) {
@@ -1182,6 +1211,18 @@ extension Media: RtmpStreamDelegate {
             } else {
                 self.delegate?.mediaOnRtmpDestinationConnected(rtmpStream.name)
             }
+        }
+    }
+}
+
+extension Media: WhipStreamDelegate {
+    func whipStreamOnConnected() {
+        delegate?.mediaOnWhipConnected()
+    }
+
+    func whipStreamOnDisconnected(reason: String) {
+        DispatchQueue.main.async {
+            self.delegate?.mediaOnWhipDisconnected(reason)
         }
     }
 }

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -627,9 +627,9 @@ final class Media: NSObject {
         ristStream?.stop()
     }
 
-    func whipStartStream(url: String, bearerToken: String) {
+    func whipStartStream(url: String, bearerToken: String, stunServers: [String]) {
         adaptiveBitrate = nil
-        whipStream?.start(url: url, bearerToken: bearerToken)
+        whipStream?.start(url: url, bearerToken: bearerToken, stunServers: stunServers)
     }
 
     func whipStopStream() {

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -189,6 +189,8 @@ extension Model {
             startNetStreamSrt()
         case .rist:
             startNetStreamRist()
+        case .whip:
+            startNetStreamWhip()
         }
         updateSpeed(now: .now)
         streamBecameBrokenTime = nil
@@ -234,12 +236,25 @@ extension Model {
         updateAdaptiveBitrateRistIfEnabled()
     }
 
+    private func startNetStreamWhip() {
+        if stream.codec != .h264avc {
+            stream.codec = .h264avc
+            setStreamCodec()
+        }
+        if stream.audioCodec != .opus {
+            stream.audioCodec = .opus
+            setAudioStreamFormat(format: .opus)
+        }
+        media.whipStartStream(url: stream.url, bearerToken: stream.whip.bearerToken)
+    }
+
     func stopNetStream() {
         moblink.streamer?.stopTunnels()
         reconnectTimer.stop()
         media.rtmpStopStream()
         media.srtStopStream()
         media.ristStopStream()
+        media.whipStopStream()
         streamStartTime = nil
         updateStreamUptime(now: .now)
         updateSpeed(now: .now)
@@ -528,6 +543,18 @@ extension Model {
     private func handleRistDisconnected() {
         DispatchQueue.main.async {
             self.onDisconnected(reason: "RIST disconnected")
+        }
+    }
+
+    private func handleWhipConnected() {
+        DispatchQueue.main.async {
+            self.onConnected()
+        }
+    }
+
+    private func handleWhipDisconnected(reason: String) {
+        DispatchQueue.main.async {
+            self.onDisconnected(reason: reason)
         }
     }
 
@@ -876,6 +903,14 @@ extension Model: MediaDelegate {
 
     func mediaOnRistDisconnected() {
         handleRistDisconnected()
+    }
+
+    func mediaOnWhipConnected() {
+        handleWhipConnected()
+    }
+
+    func mediaOnWhipDisconnected(_ reason: String) {
+        handleWhipDisconnected(reason: reason)
     }
 
     func mediaOnAudioMuteChange() {

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -245,7 +245,11 @@ extension Model {
             stream.audioCodec = .opus
             setAudioStreamFormat(format: .opus)
         }
-        media.whipStartStream(url: stream.url, bearerToken: stream.whip.bearerToken)
+        media.whipStartStream(
+            url: stream.url,
+            bearerToken: stream.whip.bearerToken,
+            stunServers: stream.whip.stunServers
+        )
     }
 
     func stopNetStream() {

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -553,26 +553,42 @@ class SettingsStreamRist: Codable {
 
 class SettingsStreamWhip: Codable, ObservableObject {
     @Published var bearerToken: String = ""
+    @Published var stunServers: [String] = []
 
     init() {}
 
     enum CodingKeys: CodingKey {
-        case bearerToken
+        case bearerToken,
+             stunServers
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(.bearerToken, bearerToken)
+        try container.encode(.stunServers, stunServers)
     }
 
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         bearerToken = container.decode(.bearerToken, String.self, "")
+        if let stunServersArray = try? container.decode([String].self, forKey: .stunServers) {
+            stunServers = stunServersArray
+                .map { $0.trim() }
+                .filter { !$0.isEmpty }
+        } else if let stunServersString = try? container.decode(String.self, forKey: .stunServers) {
+            stunServers = stunServersString
+                .split(whereSeparator: { [",", ";", "\n"].contains($0) })
+                .map { $0.trim() }
+                .filter { !$0.isEmpty }
+        } else {
+            stunServers = []
+        }
     }
 
     func clone() -> SettingsStreamWhip {
         let new = SettingsStreamWhip()
         new.bearerToken = bearerToken
+        new.stunServers = stunServers
         return new
     }
 }

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -151,6 +151,7 @@ enum SettingsStreamProtocol: String, Codable {
     case rtmp = "RTMP"
     case srt = "SRT"
     case rist = "RIST"
+    case whip = "WHIP"
 
     init(from decoder: Decoder) throws {
         self = try SettingsStreamProtocol(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ??
@@ -164,6 +165,8 @@ enum SettingsStreamDetailedProtocol {
     case srt
     case srtla
     case rist
+    case whip
+    case whips
 }
 
 class SettingsStreamSrtConnectionPriority: Codable, Identifiable {
@@ -544,6 +547,32 @@ class SettingsStreamRist: Codable {
         let new = SettingsStreamRist()
         new.adaptiveBitrateEnabled = adaptiveBitrateEnabled
         new.bonding = bonding
+        return new
+    }
+}
+
+class SettingsStreamWhip: Codable, ObservableObject {
+    @Published var bearerToken: String = ""
+
+    init() {}
+
+    enum CodingKeys: CodingKey {
+        case bearerToken
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(.bearerToken, bearerToken)
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        bearerToken = container.decode(.bearerToken, String.self, "")
+    }
+
+    func clone() -> SettingsStreamWhip {
+        let new = SettingsStreamWhip()
+        new.bearerToken = bearerToken
         return new
     }
 }
@@ -1028,6 +1057,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
     var srt: SettingsStreamSrt = .init()
     var rtmp: SettingsStreamRtmp = .init()
     var rist: SettingsStreamRist = .init()
+    var whip: SettingsStreamWhip = .init()
     @Published var maxKeyFrameInterval: Int32 = 2
     @Published var audioCodec: SettingsStreamAudioCodec = .aac
     var audioBitrate: Int = 128_000
@@ -1113,6 +1143,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
              srt,
              rtmp,
              rist,
+             whip,
              captureSessionPresetEnabled,
              captureSessionPreset,
              maxKeyFrameInterval,
@@ -1197,6 +1228,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         try container.encode(.srt, srt)
         try container.encode(.rtmp, rtmp)
         try container.encode(.rist, rist)
+        try container.encode(.whip, whip)
         try container.encode(.maxKeyFrameInterval, maxKeyFrameInterval)
         try container.encode(.audioCodec, audioCodec)
         try container.encode(.audioBitrate, audioBitrate)
@@ -1290,6 +1322,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         srt = container.decode(.srt, SettingsStreamSrt.self, .init())
         rtmp = container.decode(.rtmp, SettingsStreamRtmp.self, .init())
         rist = container.decode(.rist, SettingsStreamRist.self, .init())
+        whip = container.decode(.whip, SettingsStreamWhip.self, .init())
         maxKeyFrameInterval = container.decode(.maxKeyFrameInterval, Int32.self, 2)
         audioCodec = container.decode(.audioCodec, SettingsStreamAudioCodec.self, .aac)
         audioBitrate = container.decode(.audioBitrate, Int.self, 128_000)
@@ -1374,6 +1407,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         new.srt = srt.clone()
         new.rtmp = rtmp.clone()
         new.rist = rist.clone()
+        new.whip = whip.clone()
         new.maxKeyFrameInterval = maxKeyFrameInterval
         new.audioCodec = audioCodec
         new.audioBitrate = audioBitrate
@@ -1410,6 +1444,14 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
             return .srt
         case "rist":
             return .rist
+        case "whip":
+            return .whip
+        case "whips":
+            return .whip
+        case "http":
+            return .whip
+        case "https":
+            return .whip
         default:
             return .rtmp
         }
@@ -1427,6 +1469,14 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
             return .srtla
         case "rist":
             return .rist
+        case "whip":
+            return .whip
+        case "whips":
+            return .whips
+        case "http":
+            return .whip
+        case "https":
+            return .whips
         default:
             return .rtmp
         }
@@ -1437,6 +1487,8 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
             return "SRTLA"
         } else if getProtocol() == .rtmp && isRtmps() {
             return "RTMPS"
+        } else if getProtocol() == .whip {
+            return "WHIP"
         } else {
             return getProtocol().rawValue
         }

--- a/Moblin/View/Settings/Streams/Stream/StreamSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/StreamSettingsView.swift
@@ -270,6 +270,12 @@ struct StreamSettingsView: View {
                         } label: {
                             Text("RIST")
                         }
+                    case .whip:
+                        NavigationLink {
+                            StreamWhipSettingsView(stream: stream)
+                        } label: {
+                            Text("WHIP")
+                        }
                     }
                 }
             } header: {

--- a/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
@@ -108,6 +108,27 @@ private struct SrtHelpView: View {
     }
 }
 
+private struct WhipHelpView: View {
+    var body: some View {
+        Section {
+            VStack(alignment: .leading) {
+                Text("Template: https://my_whip_server/whip/endpoint")
+                Text("Example: https://whip.example.com/ingest/stream")
+            }
+        } header: {
+            Text("WHIP")
+        }
+        Section {
+            VStack(alignment: .leading) {
+                Text("Also supported: whips:// and whip://")
+                Text("whips:// maps to https://, whip:// maps to http://")
+            }
+        } footer: {
+            Text("WHIP sends one H.264 video track and one Opus audio track.")
+        }
+    }
+}
+
 private struct UrlSettingsView: View {
     @EnvironmentObject var model: Model
     @Environment(\.dismiss) var dismiss
@@ -173,6 +194,7 @@ private struct UrlSettingsView: View {
                             if showSrtHelp {
                                 SrtHelpView()
                             }
+                            WhipHelpView()
                         }
                         .navigationTitle("Help")
                         .toolbar {

--- a/Moblin/View/Settings/Streams/Stream/Whip/StreamWhipSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Whip/StreamWhipSettingsView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct StreamWhipSettingsView: View {
+    @EnvironmentObject var model: Model
+    @ObservedObject var stream: SettingsStream
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Bearer token (optional)", text: $stream.whip.bearerToken)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                    .disabled(stream.enabled && model.isLive)
+                    .onChange(of: stream.whip.bearerToken) { _ in
+                        model.reloadStreamIfEnabled(stream: stream)
+                    }
+            } footer: {
+                Text(
+                    "Optional token sent as Authorization: Bearer <token> when connecting to the WHIP server."
+                )
+            }
+        }
+        .navigationTitle("WHIP")
+    }
+}

--- a/Moblin/View/Settings/Streams/Stream/Whip/StreamWhipSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Whip/StreamWhipSettingsView.swift
@@ -10,7 +10,7 @@ struct StreamWhipSettingsView: View {
                 TextField("Bearer token (optional)", text: $stream.whip.bearerToken)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
-                    .disabled(stream.enabled && model.isLive)
+                    .disabled(isLocked)
                     .onChange(of: stream.whip.bearerToken) { _ in
                         model.reloadStreamIfEnabled(stream: stream)
                     }
@@ -19,7 +19,49 @@ struct StreamWhipSettingsView: View {
                     "Optional token sent as Authorization: Bearer <token> when connecting to the WHIP server."
                 )
             }
+            Section {
+                ForEach(Array(stream.whip.stunServers.indices), id: \.self) { index in
+                    TextField("stun:stun.example.com:3478", text: stunServerBinding(index))
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .disabled(isLocked)
+                }
+                .onDelete(perform: deleteStunServers)
+
+                Button {
+                    stream.whip.stunServers.append("")
+                    model.reloadStreamIfEnabled(stream: stream)
+                } label: {
+                    Label("Add STUN server", systemImage: "plus")
+                }
+                .disabled(isLocked)
+            } footer: {
+                Text(
+                    "Optional STUN server list. Example: stun:stun.example.com:3478"
+                )
+            }
         }
         .navigationTitle("WHIP")
+    }
+
+    private var isLocked: Bool {
+        stream.enabled && model.isLive
+    }
+
+    private func stunServerBinding(_ index: Int) -> Binding<String> {
+        return Binding(
+            get: {
+                stream.whip.stunServers[index]
+            },
+            set: { newValue in
+                stream.whip.stunServers[index] = newValue
+                model.reloadStreamIfEnabled(stream: stream)
+            }
+        )
+    }
+
+    private func deleteStunServers(at offsets: IndexSet) {
+        stream.whip.stunServers.remove(atOffsets: offsets)
+        model.reloadStreamIfEnabled(stream: stream)
     }
 }

--- a/MoblinTests/SettingsSuite.swift
+++ b/MoblinTests/SettingsSuite.swift
@@ -25,4 +25,27 @@ struct SettingsSuite {
                                        .init(id: 0, text: "ho"),
                                    ]))
     }
+
+    @Test
+    func whipProtocol() {
+        let stream = SettingsStream(name: "WHIP")
+        stream.url = "https://whip.example.com/live/123"
+        #expect(stream.getProtocol() == .whip)
+        #expect(stream.protocolString() == "WHIP")
+
+        stream.url = "whips://whip.example.com/live/123"
+        #expect(stream.getProtocol() == .whip)
+        #expect(stream.protocolString() == "WHIP")
+
+        stream.url = "whip://whip.example.com/live/123"
+        #expect(stream.getProtocol() == .whip)
+        #expect(stream.protocolString() == "WHIP")
+    }
+
+    @Test
+    func whipUrlValidation() {
+        #expect(isValidUrl(url: "https://whip.example.com/live/123") == nil)
+        #expect(isValidUrl(url: "whips://whip.example.com/live/123") == nil)
+        #expect(isValidUrl(url: "whip://whip.example.com/live/123") == nil)
+    }
 }

--- a/Packages/LibDataChannelPackage/Package.swift
+++ b/Packages/LibDataChannelPackage/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "LibDataChannelPackage",
+    platforms: [
+        .iOS(.v15),
+        .macCatalyst(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(name: "libdatachannel", targets: ["libdatachannel"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "libdatachannel",
+            url: "https://github.com/HaishinKit/libdatachannel-xcframework/releases/download/v0.24.0/libdatachannel.xcframework.zip",
+            checksum: "52163eed2c9d652d913b20d1fd5a1925c5982b1dcdf335fd916c72ffa385bb26"
+        ),
+    ]
+)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new end-to-end streaming transport using WebRTC/WHIP plus a new binary dependency (`libdatachannel`) and low-level RTP packetization, which could introduce connectivity or media timing issues. Also changes Opus encoder output to a fixed 48 kHz sample rate, affecting any Opus-based outputs.
> 
> **Overview**
> Adds **WHIP/WebRTC streaming output** as a new `SettingsStreamProtocol` (`whip`/`whips`, plus `http`/`https` treated as WHIP endpoints), including URL validation and localized user-facing error/help strings.
> 
> Implements a new `WhipStream` backed by `libdatachannel` (added as a local Swift package binary target) that negotiates SDP over HTTP `POST` and tears down sessions via `DELETE`, packetizes H.264 and Opus for sending, and wires WHIP connect/disconnect events through `Media`/`ModelStream`. Also updates Opus encoding to always output at **48 kHz** to match the Opus RTP clock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbd5b457608d22eb1fd181aaa137901b971bc20b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->